### PR TITLE
Include <string.h> to fix compiler warnings

### DIFF
--- a/bl2sig.c
+++ b/bl2sig.c
@@ -4,6 +4,8 @@
 // ./aml_encrypt_g12b --bl2sig --input bl2_new.bin \
 //                             --output bl2.n.bin.sig
 
+#include <string.h>
+
 #include "types.h"
 #include "lib.h"
 

--- a/bl30sig.c
+++ b/bl30sig.c
@@ -4,6 +4,8 @@
 // ./aml_encrypt_g12b --bl30sig --input bl30_new.bin \
 //                              --output bl30_new.bin.g12a.enc --level v3
 
+#include <string.h>
+
 #include "types.h"
 #include "lib.h"
 

--- a/bl3sig.c
+++ b/bl3sig.c
@@ -5,6 +5,8 @@
 // ./aml_encrypt_g12b --bl3sig  --input bl31.img              --output bl31.img.enc          --level v3 --type bl31
 // ./aml_encrypt_g12b --bl3sig  --input bl33.bin              --output bl33.bin.enc          --level v3 --type bl33 --compress lz4
 
+#include <string.h>
+
 #include "types.h"
 #include "lib.h"
 #include "lz4hc.h"

--- a/bootmk.c
+++ b/bootmk.c
@@ -18,6 +18,8 @@
 //                    --ddrfw7 diag_lpddr4.fw \
 //                    --ddrfw8 aml_ddr.fw
 
+#include <string.h>
+
 #include "types.h"
 #include "lib.h"
 

--- a/pkg.c
+++ b/pkg.c
@@ -18,6 +18,9 @@
 //
 // ACS is probably Amlogic Configurable SPL
 //
+
+#include <string.h>
+
 #include "types.h"
 #include "lib.h"
 


### PR DESCRIPTION
There are a lot of warnings as the following:

warning: implicit declaration of function ‘strcpy’